### PR TITLE
More specific Yandex service blocking

### DIFF
--- a/disconnect-blacklist.json
+++ b/disconnect-blacklist.json
@@ -5893,14 +5893,21 @@
             {
                 "Yandex": {
                     "http://www.yandex.com/": [
-                        "web-visor.com",
-                        "moikrug.ru",
-                        "yandex.com",
-                        "yandex.ru",
-                        "yandex.st",
-                        "yandex.ua",
-                        "yandex.com.tr",
-                        "yandex.by"
+                        "metrica.yandex.com.tr",
+                        "metrika.yandex.kz",
+                        "metrika.yandex.by",
+                        "metrika.yandex.ua",
+                        "metrika.yandex.ru",
+                        "metrica.yandex.com",
+                        "advertising.yandex.ru",
+                        "advertising.yandex.com",
+                        "direct.yandex.ru",
+                        "direct.yandex.com",
+                        "appmetrika.yandex.ru",
+                        "appmetrica.yandex.com",
+                        "appmetrica.yandex.com.tr",
+                        "api-metrika.yandex.com",
+                        "api-metrika.yandex.ru"
                     ]
                 }
             },

--- a/disconnect-blacklist.json
+++ b/disconnect-blacklist.json
@@ -8353,6 +8353,20 @@
                 }
             },
             {
+                "Yandex": {
+                    "http://www.yandex.com/": [
+                        "yandex.com",
+                        "web-visor.com",
+                        "moikrug.ru",
+                        "yandex.ru",
+                        "yandex.st",
+                        "yandex.ua",
+                        "yandex.com.tr",
+                        "yandex.by"
+                    ]
+                }
+            },
+            {
                 "Zendesk": {
                     "http://www.zendesk.com/": [
                         "zendesk.com"

--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -7224,10 +7224,7 @@
         ],
         "resources": [
             "yandex.com",
-            "web-visor.com",
-            "moikrug.ru",
             "yandex.ru",
-            "yandex.st",
             "yandex.ua",
             "yandex.com.tr",
             "yandex.by"


### PR DESCRIPTION
Blocking all of Yandex is probably too broad and may cause a bad UX on some sites.