### PR TITLE
Lakana provides CMS hosting for media companies.

### DIFF
--- a/disconnect-blacklist.json
+++ b/disconnect-blacklist.json
@@ -3318,7 +3318,6 @@
             {
                 "Lakana": {
                     "http://www.lakana.com/": [
-                        "lakana.com",
                         "ibsys.com"
                     ]
                 }


### PR DESCRIPTION
The lakana.com url is used by some of our clients for hosting their static content (images, js, css, videos).  Our clients websites break under private browsing mode with this entry in the list.

We've attempted to contact disconnect.me to make this change, but have received no response to our requests.