### PR TITLE
for #16: check duplicate entities in json_verify

### DIFF
--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -5704,14 +5704,12 @@
     },
     "QUISMA": {
         "properties": [
-            "i-behavior.com",
             "iaded.com",
             "quisma.com",
             "quismatch.com",
             "xmladed.com"
         ],
         "resources": [
-            "i-behavior.com",
             "iaded.com",
             "quisma.com",
             "quismatch.com",

--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -2009,14 +2009,6 @@
             "pulsemgr.com"
         ]
     },
-    "BuzzCity": {
-        "properties": [
-            "buzzcity.com"
-        ],
-        "resources": [
-            "buzzcity.com"
-        ]
-    },
     "BuzzParadise": {
         "properties": [
             "buzzparadise.com"
@@ -3273,14 +3265,6 @@
         "resources": [
             "flite.com",
             "widgetserver.com"
-        ]
-    },
-    "Flurry": {
-        "properties": [
-            "flurry.com"
-        ],
-        "resources": [
-            "flurry.com"
         ]
     },
     "Flytxt": {
@@ -9356,14 +9340,6 @@
         ],
         "resources": [
             "trumba.com"
-        ]
-    },
-    "Tumblr": {
-        "properties": [
-            "tumblr.com"
-        ],
-        "resources": [
-            "tumblr.com"
         ]
     },
     "Turn": {

--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -920,16 +920,6 @@
             "dmtry.com"
         ]
     },
-    "AdOn Network": {
-        "properties": [
-            "adonnetwork.com",
-            "dashboardad.net"
-        ],
-        "resources": [
-            "adonnetwork.com",
-            "dashboardad.net"
-        ]
-    },
     "AdOnion": {
         "properties": [
             "adonion.com"

--- a/scripts/json_verify.py
+++ b/scripts/json_verify.py
@@ -124,8 +124,8 @@ def find_uris_in_entities(entitylist_json):
     for entity, types in entitylist_json.iteritems():
         assert type(entity) is UnicodeType
         assert type(types) is DictType
-        for prop_type, uris in types.iteritems():
-            assert prop_type in ["properties", "resources"]
+        for host_type, uris in types.iteritems():
+            assert host_type in ["properties", "resources"]
             assert type(uris) is ListType
             [check_uri(uri) for uri in uris]
 


### PR DESCRIPTION
Implemented the logic and found existing duplicates:
```
disconnect-entitylist.json : invalid
       	Dupe: Dupe host: tumblr.com    	 in line 9363
       	Dupe: Dupe host: buzzcity.com  	 in line 2014
       	Dupe: Dupe host: adonnetwork.com       	 in line 925
       	Dupe: Dupe host: i-behavior.com	 in line 3716
       	Dupe: Dupe host: flurry.com    	 in line 3280
       	Dupe: Dupe host: tumblr.com    	 in line 9366
       	Dupe: Dupe host: buzzcity.com  	 in line 2017
       	Dupe: Dupe host: adonnetwork.com       	 in line 929
       	Dupe: Dupe host: i-behavior.com	 in line 3720
```
What should we do with the existing duplicates?