### PR TITLE
fix bug 1289621: catch non-ascii character hosts

### DIFF
--- a/scripts/json_verify.py
+++ b/scripts/json_verify.py
@@ -135,6 +135,10 @@ def check_uri(uri):
     # 	no scheme, port, fragment, path or query string
     # 	no disallowed characters
     # 	no leading/trailing garbage
+    try:
+        uri.decode('ascii')
+    except UnicodeEncodeError:
+        bad_uris.append(uri)
     parsed_uri = urlparse(uri)
     try:
         assert parsed_uri.scheme == ''


### PR DESCRIPTION
This shows more detailed error messages when the script finds a non-ascii character in the json. E.g.,
```
old_disconnect-blacklist.json : invalid
       	Error: Bad URI: facébook.com   	: in line 8
       	Error: Bad URI: ytså.net       	: in line 47
```