### PR TITLE
Remove "akamaihd.net" from "Facebook"

### DIFF
--- a/disconnect-blacklist.json
+++ b/disconnect-blacklist.json
@@ -6634,7 +6634,6 @@
       {
         "Facebook": {
           "http://www.facebook.com/": [
-            "akamaihd.net",
             "instagram.com",
             "fbcdn.net",
             "messenger.com"


### PR DESCRIPTION
akamaihd.net is not owned by Facebook, this would resuilt in a huge number of false-positives.