### PR TITLE
Add category support to list verification script

### DIFF
--- a/scripts/json_verify.py
+++ b/scripts/json_verify.py
@@ -116,6 +116,26 @@ def find_uris(categories_json):
                         ]
                     }
                 },
+                {
+                    "Example Fingerprinter": {
+                        "http://example.com/": [
+                            "example.com",
+                            "fingerprinting.example"
+                        ],
+                        "fingerprinting": "true"
+                    }
+                },
+                {
+                    "The Best Tracker LLC": {
+                        "http://tracker.example/": [
+                            "tracker.example",
+                            ...
+                        ],
+                        "fingerprinting": "true",
+                        "cryptominer": "true"
+                    }
+                },
+                ...
             ]
             ...
         }

--- a/scripts/json_verify.py
+++ b/scripts/json_verify.py
@@ -15,12 +15,12 @@ FINGERPRINTING_TAG = 'fingerprinting'
 CRYPTOMINING_TAG = 'cryptominer'
 SESSION_REPLAY_TAG = 'session-replay'
 PERFORMANCE_TAG = 'performance'
-ALL_TAGS = {
+ALL_TAGS = [
     FINGERPRINTING_TAG,
     CRYPTOMINING_TAG,
     SESSION_REPLAY_TAG,
     PERFORMANCE_TAG
-}
+]
 
 parser = argparse.ArgumentParser(description='Verify json files for shavar.')
 parser.add_argument("-f", "--file", help="filename to verify")

--- a/scripts/json_verify.py
+++ b/scripts/json_verify.py
@@ -29,7 +29,7 @@ def run(file):
     file_name = file
     try:
         verify(file)
-    except:
+    except Exception:
         errors.append("\tError: Problem handling file")
     finish()
 
@@ -53,7 +53,7 @@ def verify(file):
                 else:
                     # disconnect_entitylist.json
                     find_uris_in_entities(json_obj)
-            except:
+            except Exception:
                 errors.append("\tError: Can't parse file")
     except ValueError as e:
         # invalid json formatting
@@ -65,42 +65,42 @@ def verify(file):
         return
 
 
-"""
-categories_json is expected to match this format:
-    "categories": {
-        "Disconnect": [
-            {
-                "Facebook": {
-                    "http://www.facebook.com/": [
-                        "facebook.com",
-                        ...
-                    ]
-                }
-            },
-            {
-                "Google": {
-                    "http://www.google.com/": [
-                        "2mdn.net",
-                        ...
-                    ]
-                }
-            },
-            ...
-        ],
-        "Advertising": [
-            {
-                "[x+1]": {
-                    "http://www.xplusone.com/": [
-                        "ru4.com",
-                        ...
-                    ]
-                }
-            },
-        ]
-        ...
-    }
-"""
 def find_uris(categories_json):
+    """
+    `categories_json` is expected to match this format:
+        "categories": {
+            "Disconnect": [
+                {
+                    "Facebook": {
+                        "http://www.facebook.com/": [
+                            "facebook.com",
+                            ...
+                        ]
+                    }
+                },
+                {
+                    "Google": {
+                        "http://www.google.com/": [
+                            "2mdn.net",
+                            ...
+                        ]
+                    }
+                },
+                ...
+            ],
+            "Advertising": [
+                {
+                    "[x+1]": {
+                        "http://www.xplusone.com/": [
+                            "ru4.com",
+                            ...
+                        ]
+                    }
+                },
+            ]
+            ...
+        }
+    """
     assert type(categories_json) is DictType
     for category, category_json in categories_json.iteritems():
         assert type(category) is UnicodeType
@@ -181,7 +181,7 @@ def find_line_number(uri):
                 file_contents.pop(x)
                 break
     except ValueError as e:
-        print e
+        print(e)
         line = -1
     return str(line)
 
@@ -199,13 +199,13 @@ def make_errors_from_bad_uris():
 def finish():
     make_errors_from_bad_uris()
     if (len(errors) == 0):
-        print "\n" + file_name + " : valid"
+        print("\n" + file_name + " : valid")
     else:
         global result
         result = 1
-        print "\n" + file_name + " : invalid"
+        print("\n" + file_name + " : invalid")
         for error in errors:
-            print error
+            print(error)
     reset()
 
 
@@ -235,7 +235,7 @@ def start(filename=None):
 
 args = parser.parse_args()
 start(args.file)
-print "\n block_host_uris: %s " % len(block_host_uris)
-print "\n entity_host_uris: %s " % len(entity_host_uris)
+print("\n block_host_uris: %s " % len(block_host_uris))
+print("\n entity_host_uris: %s " % len(entity_host_uris))
 assert "itisatracker.com" in block_host_uris
 exit(result)

--- a/scripts/json_verify.py
+++ b/scripts/json_verify.py
@@ -5,8 +5,22 @@ import argparse
 import glob
 import json
 import re
+import sys
+import traceback
+from collections import Counter
 from types import DictType, ListType, UnicodeType
 from urlparse import urlparse
+
+FINGERPRINTING_TAG = 'fingerprinting'
+CRYPTOMINING_TAG = 'cryptominer'
+SESSION_REPLAY_TAG = 'session-replay'
+PERFORMANCE_TAG = 'performance'
+ALL_TAGS = {
+    FINGERPRINTING_TAG,
+    CRYPTOMINING_TAG,
+    SESSION_REPLAY_TAG,
+    PERFORMANCE_TAG
+}
 
 parser = argparse.ArgumentParser(description='Verify json files for shavar.')
 parser.add_argument("-f", "--file", help="filename to verify")
@@ -16,6 +30,7 @@ dupe_hosts = {
     "properties": [],
     "resources": []
 }
+tag_counts = Counter()
 block_host_uris = []
 entity_host_uris = []
 errors = []
@@ -53,15 +68,19 @@ def verify(file):
                 else:
                     # disconnect_entitylist.json
                     find_uris_in_entities(json_obj)
-            except Exception:
-                errors.append("\tError: Can't parse file")
+            except Exception as e:
+                excp = traceback.format_exception(*sys.exc_info())
+                errors.append(
+                    "---Error: Recieved error %s while parsing file.\n%s" % (
+                        type(e), ''.join(excp))
+                )
     except ValueError as e:
         # invalid json formatting
-        errors.append("\tError: %s" % e)
+        errors.append("---Error: %s" % e)
         return
     except IOError as e:
         # non-existent file
-        errors.append("\tError: Can't open file: %s" % e)
+        errors.append("---Error: Can't open file: %s" % e)
         return
 
 
@@ -117,6 +136,13 @@ def find_uris(categories_json):
                 except AssertionError:
                     errors.append("%s has bad DNT value: %s" % (entity_name,
                                                                 dnt_value))
+                # pop sub-category tags out of the dict
+                for tag in ALL_TAGS:
+                    tag_value = entity_json.pop(tag, '')
+                    assert tag_value in ["true", ""]
+                    if tag_value == "":
+                        continue
+                    tag_counts[tag] += 1
                 for domain, uris in entity_json.iteritems():
                     assert type(domain) is UnicodeType
                     assert type(uris) is ListType
@@ -236,6 +262,8 @@ def start(filename=None):
 args = parser.parse_args()
 start(args.file)
 print("\n block_host_uris: %s " % len(block_host_uris))
+for tag in ALL_TAGS:
+    print("    -> %15s: %4d" % (tag, tag_counts[tag]))
 print("\n entity_host_uris: %s " % len(entity_host_uris))
 assert "itisatracker.com" in block_host_uris
 exit(result)


### PR DESCRIPTION
In https://github.com/mozilla-services/shavar-list-creation-config/pull/35 and https://github.com/mozilla-services/shavar-list-creation/pull/62 we added support for Disconnect's new sub-category tags. This PR updates the list verification script to accept a list with these tags and include a summary in the output.