### PR TITLE
Facebook and shareaholic updates from Disconnect for both blacklist and STP

### DIFF
--- a/disconnect-blacklist.json
+++ b/disconnect-blacklist.json
@@ -4429,7 +4429,6 @@
             "adbureau.net",
             "adecn.com",
             "aquantive.com",
-            "atdmt.com",
             "msads.net",
             "netconversions.com",
             "roiservice.com"
@@ -10968,12 +10967,14 @@
       {
         "Facebook": {
           "http://www.facebook.com/": [
+            "atdmt.com",
             "atlassolutions.com",
             "facebook.com",
             "facebook.de",
             "facebook.fr",
             "facebook.net",
             "fb.com",
+            "fbsbx.com",
             "friendfeed.com"
           ]
         }

--- a/disconnect-blacklist.json
+++ b/disconnect-blacklist.json
@@ -10715,9 +10715,7 @@
       {
         "Shareaholic": {
           "http://www.shareaholic.com/": [
-            "buzzster.com",
-            "shareaholic.com",
-            "shareaholic.net"
+            "shareaholic.com"
           ]
         }
       },

--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -4554,6 +4554,7 @@
       "messenger.com"
     ],
     "resources": [
+      "atdmt.com",
       "atlassolutions.com",
       "facebook.com",
       "facebook.de",
@@ -4562,6 +4563,7 @@
       "fb.com",
       "fb.me",
       "fbcdn.net",
+      "fbsbx.com",
       "friendfeed.com",
       "instagram.com",
       "messenger.com"
@@ -7191,7 +7193,6 @@
   },
   "Microsoft": {
     "properties": [
-      "atdmt.com",
       "bing.com",
       "gamesforwindows.com",
       "getgamesmart.com",
@@ -7218,7 +7219,6 @@
       "adbureau.net",
       "adecn.com",
       "aquantive.com",
-      "atdmt.com",
       "bing.com",
       "gamesforwindows.com",
       "getgamesmart.com",

--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -9472,13 +9472,10 @@
   },
   "Shareaholic": {
     "properties": [
-      "buzzster.com",
       "shareaholic.com"
     ],
     "resources": [
-      "buzzster.com",
-      "shareaholic.com",
-      "shareaholic.net"
+      "shareaholic.com"
     ]
   },
   "ShareASale": {

--- a/social-tracking-protection-blacklist.json
+++ b/social-tracking-protection-blacklist.json
@@ -13,6 +13,7 @@
                      "facebook.fr",
                      "fb.com",
                      "fbcdn.net",
+                     "fbsbx.com",
                      "friendfeed.com",
 
                      "instagram.com",


### PR DESCRIPTION
Supersedes https://github.com/mozilla-services/shavar-prod-lists/pull/71 with a commit to make STP block-list match new Disconnect domains.

Merging this will effectively bundle all the list updates together.