### PR TITLE
Recent Disconnect list removals or entity updates

### DIFF
--- a/disconnect-blacklist.json
+++ b/disconnect-blacklist.json
@@ -10602,13 +10602,6 @@
         }
       },
       {
-        "StackTrack": {
-          "http://stat-track.com": [
-            "stat-track.com"
-          ]
-        }
-      },
-      {
         "Storeland": {
           "https://storeland.ru/": [
             "storeland.ru"

--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -4566,6 +4566,7 @@
       "internalfb.com",
       "messenger.com",
       "oculus.com",
+      "whatsapp.com",
       "workplace.com"
     ],
     "resources": [

--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -5152,6 +5152,7 @@
       "abc.xyz",
       "admeld.com",
       "blogger.com",
+      "blogspot.com",
       "crashlytics.com",
       "google-melange.com",
       "google.ac",


### PR DESCRIPTION
adds blogspot.com as Google property: https://github.com/disconnectme/disconnect-tracking-protection/commit/e363db5b78752e7a2861bf5d9a931ef539f018f6