### PR TITLE
TravisCI status on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # shavar-prod-lists
+
+[![Build Status](https://travis-ci.org/mozilla-services/shavar-prod-lists.svg?branch=master)](https://travis-ci.org/mozilla-services/shavar-prod-lists)
+
 This repo serves as a staging area for
 [shavar](https://github.com/mozilla-services/shavar) /
 [tracking protection](https://wiki.mozilla.org/Security/Tracking_protection)


### PR DESCRIPTION
This pull requests adds a TravisCI master build status badge to the project's README file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-services/shavar-prod-lists/177)
<!-- Reviewable:end -->
