### PR TITLE
Recent Disconnect list additions

### DIFF
--- a/disconnect-blacklist.json
+++ b/disconnect-blacklist.json
@@ -3164,6 +3164,13 @@
         }
       },
       {
+        "Flocktory": {
+          "https://www.flocktory.com/en/": [
+            "flocktory.com"
+          ]
+        }
+      },
+      {
         "Fluct": {
           "https://corp.fluct.jp/": [
             "adingo.jp",

--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -4810,6 +4810,14 @@
       "widgetserver.com"
     ]
   },
+  "Flocktory": {
+    "properties": [
+      "flocktory.com"
+    ],
+    "resources": [
+      "flocktory.com"
+    ]
+  },
   "Fluct": {
     "properties": [
       "adingo.jp",


### PR DESCRIPTION
Adds flocktory.com as advertising tracker: https://github.com/disconnectme/disconnect-tracking-protection/commit/b1eac781277bd0b76c63fe6b9a91dd645f1ae0b1