### PR TITLE
Recent (2020-09#1) Disconnect list additions

### DIFF
--- a/disconnect-blacklist.json
+++ b/disconnect-blacklist.json
@@ -3665,6 +3665,13 @@
         }
       },
       {
+        "ie8eamus": {
+          "https://ie8eamus.com/": [
+            "ie8eamus.com"
+          ]
+        }
+      },
+      {
         "iEntry": {
           "http://www.ientry.com/": [
             "600z.com",
@@ -10322,6 +10329,15 @@
         }
       },
       {
+        "Bouncex": {
+          "https://www.bouncex.com/": [
+            "bounceexchange.com",
+            "bouncex.com",
+            "bouncex.net"
+          ]
+        }
+      },
+      {
         "Brandcrumb": {
           "http://www.brandcrumb.com": [
             "brandcrumb.com"
@@ -10508,6 +10524,13 @@
         }
       },
       {
+        "ie8eamus": {
+          "https://ie8eamus.com/": [
+            "ie8eamus.com"
+          ]
+        }
+      },
+      {
         "iMedia": {
           "http://www.imedia.cz": [
             "imedia.cz"
@@ -10690,6 +10713,13 @@
         "PrometheusIntelligenceTechnology": {
           "https://prometheusintelligencetechnology.com/": [
             "prometheusintelligencetechnology.com"
+          ]
+        }
+      },
+      {
+        "Protected Media": {
+          "http://www.protected.media/": [
+            "ad-score.com"
           ]
         }
       },
@@ -10925,15 +10955,6 @@
             "bkrtx.com",
             "bluekai.com",
             "tracksimple.com"
-          ]
-        }
-      },
-      {
-        "Bouncex": {
-          "https://www.bouncex.com/": [
-            "bounceexchange.com",
-            "bouncex.com",
-            "bouncex.net"
           ]
         }
       },

--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -6095,6 +6095,14 @@
         "idgtechnetwork.com"
       ]
     },
+    "ie8eamus": {
+      "properties": [
+        "ie8eamus.com"
+      ],
+      "resources": [
+        "ie8eamus.com"
+      ]
+    },
     "iEntry": {
       "properties": [
         "600z.com",


### PR DESCRIPTION
Adds ad-score as invasive fingerprinter: https://github.com/disconnectme/disconnect-tracking-protection/commit/d1f6a992dcc6c02430aa13986d8b51d3de2a29df
adds ie8eamus.com as tracker and FingerprintingInvasive: https://github.com/disconnectme/disconnect-tracking-protection/commit/36ce842065f1a2d07a7c838c3776d31099073d17
Moves BounceExchange to FingerprintingInvasive: https://github.com/disconnectme/disconnect-tracking-protection/commit/a73a200122a5645b4a55191d886bce4446ee7150