### PR TITLE
Compare shavar and disconnect

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,16 @@ jobs:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9']
     steps:
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Verify JSON
-      run: python ./scripts/json_verify.py
+      run: python scripts/json_verify.py
     - name: Diff current blocklist with remote
-      run: python ./scripts/compare_remote.py
+      run: python scripts/compare_remote.py
     - name: Diff current blocklist with Disconnect
-      run: python ./scripts/compare_remote.py -d
+      run: python scripts/compare_remote.py -d
     - name: Upload coverage
       run: python -m codecov --name "Python ${{ matrix.python-version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
@@ -16,6 +16,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade requests
     - name: Verify JSON
       run: python scripts/json_verify.py
     - name: Diff current blocklist with remote

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Verify JSON
-      run: python scripts/json_verify.py
+      run: python ./scripts/json_verify.py
     - name: Diff current blocklist with remote
-      run: python scripts/compare_remote.py
+      run: python ./scripts/compare_remote.py
     - name: Diff current blocklist with Disconnect
-      run: python scripts/compare_remote.py -d
+      run: python ./scripts/compare_remote.py -d
     - name: Upload coverage
       run: python -m codecov --name "Python ${{ matrix.python-version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -25,5 +25,3 @@ jobs:
       run: python scripts/compare_remote.py
     - name: Diff current blocklist with Disconnect
       run: python scripts/compare_remote.py -d
-    - name: Upload coverage
-      run: python -m codecov --name "Python ${{ matrix.python-version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: build (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9']
+    steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Verify JSON
+      run: python scripts/json_verify.py
+    - name: Diff current blocklist with remote
+      run: python scripts/compare_remote.py
+    - name: Diff current blocklist with Disconnect
+      run: python scripts/compare_remote.py -d
+    - name: Upload coverage
+      run: python -m codecov --name "Python ${{ matrix.python-version }}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: python
-python:
-  - "3.7"
-sudo: false
-
-script: scripts/json_verify.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.7"
 sudo: false
 
 script: scripts/json_verify.py

--- a/scripts/compare_disconnect.py
+++ b/scripts/compare_disconnect.py
@@ -5,16 +5,16 @@ import requests
 import json
 import argparse
 
-parser = argparse.ArgumentParser(description='Compare Shavar and Disconnect.me blacklist.')
+parser = argparse.ArgumentParser(description='Compare Shavar and Disconnect.me blocklist.')
 # parser.add_argument("file", type=str, help="blacklist to verify")
 args = parser.parse_args()
 
 result = 0
 
-def get_unique_uris(blacklist):
+def get_unique_uris(blocklist):
     category_uris = {}
 
-    for category, category_json in blacklist['categories'].items():
+    for category, category_json in blocklist['categories'].items():
         unique_uris = {}
         for entity in category_json:
                 for entity_name, entity_json in entity.items():
@@ -28,40 +28,50 @@ def get_unique_uris(blacklist):
 
     return category_uris
 
-shavar_blacklist_json = open('disconnect-blacklist.json', 'r')
-shavar_blacklist = json.load(shavar_blacklist_json)
-# resp = requests.get('https://raw.githubusercontent.com/disconnectme/disconnect-tracking-protection/master/services.json')
-resp = requests.get('https://raw.githubusercontent.com/disconnectme/shavar-prod-lists/master/disconnect-blacklist.json')
-disconnect_blacklist = json.loads(resp.content)
-
-shavar_uris = get_unique_uris(shavar_blacklist)
-disconnect_uris = get_unique_uris(disconnect_blacklist)
-
-# check Disconnect and Shavar has the same categories
-category_diff = shavar_uris.keys() ^ disconnect_uris.keys()
-if len(category_diff) > 0:
-    result = 1
-    print('Categories do not match – diff is ' + str(category_diff))
-
-for category, unique_uris in shavar_uris.items():
-    if category in category_diff:
-        continue
-    entity_diff = unique_uris.keys() ^ disconnect_uris[category].keys()
-    if len(entity_diff) > 0:
+def compare_by_categories(curr_uris, remote_uris):
+    category_diff = curr_uris.keys() ^ remote_uris.keys()
+    if len(category_diff) > 0:
         result = 1
-        print(
-            f'{category} entities do not match – diff is ' + str(entity_diff)
-        )
+        print('Categories do not match – diff is ' + str(category_diff))
 
-    for entity in unique_uris.keys():
-        if entity in entity_diff:
+    for category, unique_uris in curr_uris.items():
+        if category in category_diff:
             continue
-        uris_diff = unique_uris[entity] ^ disconnect_uris[category][entity]
-        if(len(uris_diff) > 0):
+        entity_diff = unique_uris.keys() ^ remote_uris[category].keys()
+        if len(entity_diff) > 0:
             result = 1
             print(
-                f'URIs do not match for entity {entity} – diff is '
-                    + str(uris_diff)
+                f'{category} entities do not match – diff is ' + str(entity_diff)
             )
+
+        for entity in unique_uris.keys():
+            if entity in entity_diff:
+                continue
+            uris_diff = unique_uris[entity] ^ remote_uris[category][entity]
+            if(len(uris_diff) > 0):
+                result = 1
+                print(
+                    f'URIs do not match for entity {entity} – diff is '
+                        + str(uris_diff)
+                )
+
+curr_blcklist_json = open('disconnect-blacklist.json', 'r')
+curr_blcklist = json.load(curr_blcklist_json)
+# original repo https://raw.githubusercontent.com/disconnectme/disconnect-tracking-protection/master/services.json
+disconnect_resp = requests.get('https://raw.githubusercontent.com/disconnectme/shavar-prod-lists/master/disconnect-blacklist.json')
+shavar_resp = requests.get('disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json')
+disconnect_blocklist = json.loads(resp.content)
+shavar_blocklist = json.loads(resp.content)
+
+curr_uris = get_unique_uris(curr_blcklist)
+disconnect_uris = get_unique_uris(disconnect_blocklist)
+shavar_uris = get_unique_uris(disconnect_blocklist)
+
+# check current and remote has the same domains in the categories
+print('Diff between current changes and Disconnect')
+compare_by_categories(curr_uris, disconnect_uris)
+print('Diff between current changes and Shavar')
+compare_by_categories(curr_uris, shavar_uris)
+
 
 exit(result)

--- a/scripts/compare_disconnect.py
+++ b/scripts/compare_disconnect.py
@@ -44,6 +44,8 @@ if len(category_diff) > 0:
     print('Categories do not match – diff is ' + str(category_diff))
 
 for category, unique_uris in shavar_uris.items():
+    if category in category_diff:
+        continue
     entity_diff = unique_uris.keys() ^ disconnect_uris[category].keys()
     if len(entity_diff) > 0:
         result = 1
@@ -52,6 +54,8 @@ for category, unique_uris in shavar_uris.items():
         )
 
     for entity in unique_uris.keys():
+        if entity in entity_diff:
+            continue
         uris_diff = unique_uris[entity] ^ disconnect_uris[category][entity]
         if(len(uris_diff) > 0):
             result = 1

--- a/scripts/compare_disconnect.py
+++ b/scripts/compare_disconnect.py
@@ -1,47 +1,63 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import urllib.request, json
+import requests
+import json
 import argparse
 
 parser = argparse.ArgumentParser(description='Compare Shavar and Disconnect.me blacklist.')
-parser.add_argument("-f", "--file", help="blacklist to verify")
+# parser.add_argument("file", type=str, help="blacklist to verify")
 args = parser.parse_args()
 
 result = 0
 
 def get_unique_uris(blacklist):
-    unique_uris = {}
-    
+    category_uris = {}
+
     for category, category_json in blacklist['categories'].items():
+        unique_uris = {}
         for entity in category_json:
                 for entity_name, entity_json in entity.items():
                     for domain, uris in entity_json.items():
                         if not entity_name in unique_uris:
                             unique_uris[entity_name] = set()
-                        
+
                         for uri in uris:
                             unique_uris[entity_name].add(uri)
+        category_uris[category] = unique_uris
 
-    return unique_uris
+    return category_uris
 
-with open(args.file, encoding='utf8') as json_file:
-    shavar_blacklist = json.load(json_file)
-with urllib.request.urlopen('https://raw.githubusercontent.com/disconnectme/disconnect-tracking-protection/master/services.json') as url:
-    disconnect_blacklist = json.loads(url.read().decode())
+shavar_blacklist_json = open('disconnect-blacklist.json', 'r')
+shavar_blacklist = json.load(shavar_blacklist_json)
+# resp = requests.get('https://raw.githubusercontent.com/disconnectme/disconnect-tracking-protection/master/services.json')
+resp = requests.get('https://raw.githubusercontent.com/disconnectme/shavar-prod-lists/master/disconnect-blacklist.json')
+disconnect_blacklist = json.loads(resp.content)
 
 shavar_uris = get_unique_uris(shavar_blacklist)
 disconnect_uris = get_unique_uris(disconnect_blacklist)
 
-entity_diff = shavar_uris.keys() ^ disconnect_uris.keys()
-if len(entity_diff) > 0:
+# check Disconnect and Shavar has the same categories
+category_diff = shavar_uris.keys() ^ disconnect_uris.keys()
+if len(category_diff) > 0:
     result = 1
-    print('Entities do not match – diff is ' + str(entity_diff))
+    print('Categories do not match – diff is ' + str(category_diff))
 
-for entity in shavar_uris.keys():
-    uris_diff = shavar_uris[entity] ^ disconnect_uris[entity]
-    if(len(uris_diff) > 0):
+for category, unique_uris in shavar_uris.items():
+    entity_diff = unique_uris.keys() ^ disconnect_uris[category].keys()
+    if len(entity_diff) > 0:
         result = 1
-        print('URIs do not match for entity ' + entity + ' – diff is ' + str(uris_diff))
-        
+        print(
+            f'{category} entities do not match – diff is ' + str(entity_diff)
+        )
+
+    for entity in unique_uris.keys():
+        uris_diff = unique_uris[entity] ^ disconnect_uris[category][entity]
+        if(len(uris_diff) > 0):
+            result = 1
+            print(
+                f'URIs do not match for entity {entity} – diff is '
+                    + str(uris_diff)
+            )
+
 exit(result)

--- a/scripts/compare_remote.py
+++ b/scripts/compare_remote.py
@@ -12,7 +12,7 @@ args = parser.parse_args()
 if args.disconnect:
     github_url = 'https://raw.githubusercontent.com/disconnectme/shavar-prod-lists/master/disconnect-blacklist.json'
 else:
-    github_url = 'https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json'
+    github_url = 'https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json'
 result = 0
 
 def get_unique_uris(blocklist):

--- a/scripts/compare_remote.py
+++ b/scripts/compare_remote.py
@@ -5,10 +5,14 @@ import requests
 import json
 import argparse
 
-parser = argparse.ArgumentParser(description='Compare Shavar and Disconnect.me blocklist.')
-# parser.add_argument("file", type=str, help="blacklist to verify")
+parser = argparse.ArgumentParser(description='Compare current against Shavar or Disconnect.me blocklist. Default compare against remote.')
+parser.add_argument('-d', '--disconnect', help='Compare against Disconnect', action='store_true')
+parser.add_argument('-s', '--shavar', help='Compare against Disconnect')
 args = parser.parse_args()
-
+if args.disconnect:
+    github_url = 'https://raw.githubusercontent.com/disconnectme/shavar-prod-lists/master/disconnect-blacklist.json'
+else:
+    github_url = 'https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json'
 result = 0
 
 def get_unique_uris(blocklist):
@@ -58,20 +62,13 @@ def compare_by_categories(curr_uris, remote_uris):
 curr_blcklist_json = open('disconnect-blacklist.json', 'r')
 curr_blcklist = json.load(curr_blcklist_json)
 # original repo https://raw.githubusercontent.com/disconnectme/disconnect-tracking-protection/master/services.json
-disconnect_resp = requests.get('https://raw.githubusercontent.com/disconnectme/shavar-prod-lists/master/disconnect-blacklist.json')
-shavar_resp = requests.get('disconnect_url=https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/social-tracking-protection-blacklist.json')
-disconnect_blocklist = json.loads(resp.content)
-shavar_blocklist = json.loads(resp.content)
+resp = requests.get(github_url)
+remote_blocklist = json.loads(resp.content)
 
 curr_uris = get_unique_uris(curr_blcklist)
-disconnect_uris = get_unique_uris(disconnect_blocklist)
-shavar_uris = get_unique_uris(disconnect_blocklist)
+remote_uris = get_unique_uris(remote_blocklist)
 
 # check current and remote has the same domains in the categories
-print('Diff between current changes and Disconnect')
-compare_by_categories(curr_uris, disconnect_uris)
-print('Diff between current changes and Shavar')
-compare_by_categories(curr_uris, shavar_uris)
-
+compare_by_categories(curr_uris, remote_uris)
 
 exit(result)

--- a/scripts/json_verify.py
+++ b/scripts/json_verify.py
@@ -8,7 +8,6 @@ import re
 import sys
 import traceback
 from collections import Counter
-from types import DictType, ListType, UnicodeType
 from urllib.parse import urlparse
 
 SESSION_REPLAY_TAG = 'session-replay'
@@ -130,15 +129,15 @@ def find_uris(categories_json):
             ...
         }
     """
-    assert type(categories_json) is DictType
-    for category, category_json in categories_json.iteritems():
-        assert type(category) is UnicodeType
-        assert type(category_json) is ListType
+    assert isinstance(categories_json, dict)
+    for category, category_json in categories_json.items():
+        assert isinstance(category, str)
+        assert isinstance(category_json, list)
         for entity in category_json:
-            assert type(entity) is DictType
-            for entity_name, entity_json in entity.iteritems():
-                assert type(entity_name) is UnicodeType
-                assert type(entity_json) is DictType
+            assert isinstance(entity, dict)
+            for entity_name, entity_json in entity.items():
+                assert isinstance(entity_name, str)
+                assert isinstance(entity_json, dict)
                 # pop dnt out of the dict, so we can iteritems() over the rest
                 try:
                     dnt_value = entity_json.pop('dnt', '')
@@ -152,9 +151,9 @@ def find_uris(categories_json):
                     assert tag_value in ["true", ""]
                     if tag_value == "":
                         continue
-                for domain, uris in entity_json.iteritems():
-                    assert type(domain) is UnicodeType
-                    assert type(uris) is ListType
+                for domain, uris in entity_json.items():
+                    assert isinstance(domain, str)
+                    assert isinstance(uris, list)
                     for uri in uris:
                         check_uri(uri)
                         block_host_uris.append(uri)
@@ -166,13 +165,13 @@ def find_uris_in_entities(entitylist_json):
         "resources": []
     }
     assert len(entitylist_json.items()) > 0
-    assert type(entitylist_json) is DictType
-    for entity, types in entitylist_json.iteritems():
-        assert type(entity) is UnicodeType
-        assert type(types) is DictType
-        for host_type, uris in types.iteritems():
+    assert isinstance(entitylist_json, dict)
+    for entity, types in entitylist_json.items():
+        assert isinstance(entity, str)
+        assert isinstance(types, dict)
+        for host_type, uris in types.items():
             assert host_type in ["properties", "resources"]
-            assert type(uris) is ListType
+            assert isinstance(uris, list)
             for uri in uris:
                 if uri in checked_uris[host_type]:
                     dupe_hosts[host_type].append(uri)
@@ -225,7 +224,7 @@ def make_errors_from_bad_uris():
     for bad_uri in bad_uris:
         errors.append("\tError: Bad URI: %s\t: in line %s" %
                       (bad_uri, find_line_number(bad_uri)))
-    for host_type, hosts in dupe_hosts.iteritems():
+    for host_type, hosts in dupe_hosts.items():
         for host in hosts:
             errors.append("\tDupe: Dupe host: %s\t in line %s" %
                           (host, find_line_number(host)))

--- a/scripts/json_verify.py
+++ b/scripts/json_verify.py
@@ -185,10 +185,6 @@ def check_uri(uri):
     # 	no scheme, port, fragment, path or query string
     # 	no disallowed characters
     # 	no leading/trailing garbage
-    try:
-        uri.decode('ascii')
-    except UnicodeEncodeError:
-        bad_uris.append(uri)
     parsed_uri = urlparse(uri)
     try:
         assert parsed_uri.scheme == ''
@@ -209,7 +205,7 @@ def find_line_number(uri):
     line = 0
     try:
         for x in range(0, len(file_contents)):
-            temp = file_contents[x][0].decode("utf-8", "ignore")
+            temp = file_contents[x][0]
             if re.search(uri, temp):
                 line = file_contents[x][1]
                 file_contents.pop(x)

--- a/scripts/json_verify.py
+++ b/scripts/json_verify.py
@@ -9,7 +9,7 @@ import sys
 import traceback
 from collections import Counter
 from types import DictType, ListType, UnicodeType
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 SESSION_REPLAY_TAG = 'session-replay'
 PERFORMANCE_TAG = 'performance'


### PR DESCRIPTION
# About this PR
Maintenance work to ensure that Shavar lists are not too different from Disconnect's lists.

# Acceptance Criteria
- [ ] Update `compare_disconnect.py` such that the uris are compared at the category level rather than the entity level
- [ ] Update `verify_json.py` so it is Py3 compatible
- [ ] Move from Travis to GitHub Action as specified in #403 
- [ ] Merge to all versioned branches

#
Fix #403