### PR TITLE
Recent (2020-11#1) Disconnect list entity updates or removals

### DIFF
--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -4691,6 +4691,7 @@
         "internalfb.com",
         "messenger.com",
         "oculus.com",
+        "oversightboard.com",
         "whatsapp.com",
         "workplace.com"
       ],


### PR DESCRIPTION
See: Add oversightboard.com as Facebook property - https://github.com/disconnectme/disconnect-tracking-protection/commit/c1bdd21c5923456ca0d2312caa17b68ddff989e8