### PR TITLE
Migrate intervention policy to wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,9 @@ them into each versioned list and deploy them across all channels.
 
 #### Temporary exceptions
 
-If we discover breakage that we'd like to fix through Firefox code changes, we
-may temporarily unblock the relevant domains while we work on the fixes. To
-prevent these from becoming permanent exceptions, a deadline must be provided by
-the engineer at the time of unblocking, with a maximum deadline of 18 months.
-We may alternatively unblock domains for up to 6 months when we are working in
-collaboration with the impacted site or party to fix website breakage.
-These are tracked in [Bug 1537702](https://bugzilla.mozilla.org/show_bug.cgi?id=1537702).
+We me choose to grant a temporary domain-based exemption in response to website
+breakage as detailed in our
+[anti-tracking policy](https://wiki.mozilla.org/Security/Anti_tracking_policy#Temporary_Web_Compatibility_Interventions).
 
 #### List freezes
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ them into each versioned list and deploy them across all channels.
 
 #### Temporary exceptions
 
-We me choose to grant a temporary domain-based exemption in response to website
+We may choose to grant a temporary domain-based exemption in response to website
 breakage as detailed in our
 [anti-tracking policy](https://wiki.mozilla.org/Security/Anti_tracking_policy#Temporary_Web_Compatibility_Interventions).
 


### PR DESCRIPTION
We've decided to move the intervention policy into the wiki as we intend to use it more broadly than just for our list-based features.