### PR TITLE
Recent (2022-02#1) Disconnect entity updates or removals

### DIFF
--- a/disconnect-blacklist.json
+++ b/disconnect-blacklist.json
@@ -1,5 +1,5 @@
 {
-  "license": "Copyright 2010-2021 Disconnect, Inc. / Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International license (the “License”). A summary of the License is available here: https://creativecommons.org/licenses/by-nc-sa/4.0/. The text version of the License is here: https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.txt. Please see the License for the specific language governing permissions and limitations under the License. Unless agreed to in writing or required by law, software distributed under the License on an \"as is\" basis without warranties or conditions of any kind, either express or implied. This license does not apply to any Disconnect logos or marks contained in this repo.",
+  "license": "Copyright 2010-2022 Disconnect, Inc. / Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International license (the “License”). A summary of the License is available here: https://creativecommons.org/licenses/by-nc-sa/4.0/. The text version of the License is here: https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.txt. Please see the License for the specific language governing permissions and limitations under the License. Unless agreed to in writing or required by law, software distributed under the License on an \"as is\" basis without warranties or conditions of any kind, either express or implied. This license does not apply to any Disconnect logos or marks contained in this repo.",
   "categories": {
     "Advertising": [
       {
@@ -7345,7 +7345,8 @@
       {
         "VistaprintSchweizGmbH": {
           "https://www.vistaprint.ch/": [
-            "vpsvc.com"
+            "vpdcp.com",
+            "vptms.com"
           ]
         }
       },
@@ -11019,13 +11020,6 @@
         }
       },
       {
-        "Refersion": {
-          "https://www.refersion.com/": [
-            "refersion.com"
-          ]
-        }
-      },
-      {
         "Rollick": {
           "https://gorollick.com": [
             "rollick.io"
@@ -11540,6 +11534,13 @@
         "Polen": {
           "https://polen.com.br/": [
             "polen.com.br"
+          ]
+        }
+      },
+      {
+        "Refersion": {
+          "https://www.refersion.com/": [
+            "refersion.com"
           ]
         }
       },

--- a/disconnect-blacklist.json
+++ b/disconnect-blacklist.json
@@ -10544,13 +10544,6 @@
         }
       },
       {
-        "Ansira": {
-          "https://ansira.com/": [
-            "ansira.com"
-          ]
-        }
-      },
-      {
         "AuditedMedia": {
           "https://auditedmedia.com/": [
             "aamapi.com",
@@ -11267,6 +11260,13 @@
         "Albacross": {
           "https://albacross.com": [
             "albacross.com"
+          ]
+        }
+      },
+      {
+        "Ansira": {
+          "https://ansira.com/": [
+            "ansira.com"
           ]
         }
       },

--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -1,5 +1,5 @@
 {
-  "license": "Copyright 2010-2021 Disconnect, Inc. / Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International license (the “License”). A summary of the License is available here: https://creativecommons.org/licenses/by-nc-sa/4.0/. The text version of the License is here: https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.txt. Please see the License for the specific language governing permissions and limitations under the License. Unless agreed to in writing or required by law, software distributed under the License on an \"as is\" basis without warranties or conditions of any kind, either express or implied. This license does not apply to any Disconnect logos or marks contained in this repo.",
+  "license": "Copyright 2010-2022 Disconnect, Inc. / Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International license (the “License”). A summary of the License is available here: https://creativecommons.org/licenses/by-nc-sa/4.0/. The text version of the License is here: https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.txt. Please see the License for the specific language governing permissions and limitations under the License. Unless agreed to in writing or required by law, software distributed under the License on an \"as is\" basis without warranties or conditions of any kind, either express or implied. This license does not apply to any Disconnect logos or marks contained in this repo.",
   "entities": {
     "1plusx": {
       "properties": [
@@ -12237,7 +12237,8 @@
         "vistaprint.com"
       ],
       "resources": [
-        "vpsvc.com"
+        "vpdcp.com",
+        "vptms.com"
       ]
     },
     "vistrac": {

--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -1696,6 +1696,7 @@
         "junglee.com",
         "look.com",
         "pillpack.com",
+        "sagemaker.aws",
         "shopbop.com",
         "souq.com",
         "twitch.com",


### PR DESCRIPTION
Recent Disconnect list entity updates, removals, or updating fingerprinting categorization from invasive to general. Please see individual commits for details. @say-yawn, please let me know if you have any questions. Thanks!

Moves Refersion from invasive to general fp. See: https://github.com/disconnectme/disconnect-tracking-protection/commit/dab5b07e1a8b961cb2475cc7d66fc505bccbbc3b

Replaces vpsvc.com with vpdcp.com and vptms.com. See: https://github.com/disconnectme/disconnect-tracking-protection/commit/5b28d0adbafda7b6954251a4ff04b9707a260bf1