### PR TITLE
Fix: Update Wrongly Labeled Domain

### DIFF
--- a/disconnect-blacklist.json
+++ b/disconnect-blacklist.json
@@ -1838,7 +1838,6 @@
             "adknowledge.com",
             "adparlor.com",
             "bidsystem.com",
-            "cubics.com",
             "lookery.com"
           ]
         }

--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -800,14 +800,12 @@
         "adknowledge.com",
         "adparlor.com",
         "bidsystem.com",
-        "cubics.com",
         "lookery.com"
       ],
       "resources": [
         "adknowledge.com",
         "adparlor.com",
         "bidsystem.com",
-        "cubics.com",
         "lookery.com"
       ]
     },


### PR DESCRIPTION
Submitting a PR to remove a domain that was used for ad-tracking 10 years ago. The domain was parked and is not used for anything ad-related any longer, kindly remove it from the block lists (because Firefox keeps blocking cross-origin requests to it, wrongly labeling it as an ad tracker). 