### PR TITLE
Recent (2025-06#1) Disconnect entity updates, re-categorizations, and removals 

### DIFF
--- a/disconnect-entitylist.json
+++ b/disconnect-entitylist.json
@@ -2165,6 +2165,7 @@
         "cloudfront.net",
         "imdb.com",
         "serving-sys.com",
+        "ttvnw.net",
         "twitch.tv"
       ]
     },


### PR DESCRIPTION
Adds `ttvnw.net` as `Amazon` resource