### PR TITLE
Socket.dev data exfiltration C2 domains added

### DIFF
--- a/harmful-addon-protection-blacklist.json
+++ b/harmful-addon-protection-blacklist.json
@@ -57,22 +57,8 @@
       "gfsg4f5.top",
       "headerapi.com",
       "cloudapi.stream",
-      "mines.cloudapi.stream",
-      "topup.cloudapi.stream",
-      "wheel.cloudapi.stream",
       "top.rodeo",
-      "herculessportslegend.cloudapi.stream",
-      "tg.cloudapi.stream",
-      "goldminer.cloudapi.stream",
-      "api.cloudapi.stream",
-      "www.dummysoftware.com",
-      "cdn.cloudapi.stream",
-      "multiaccount.cloudapi.stream",
-      "gamewss.cloudapi.stream",
-      "chat.cloudapi.stream",
-      "crm.cloudapi.stream",
-      "metal.cloudapi.stream",
-      "coin-miner.cloudapi.stream"
+      "www.dummysoftware.com"
      ]
     }
    }

--- a/harmful-addon-protection-blacklist.json
+++ b/harmful-addon-protection-blacklist.json
@@ -55,7 +55,24 @@
       "traxa41.net",
       "784bcct.life",
       "gfsg4f5.top",
-      "headerapi.com"
+      "headerapi.com",
+      "cloudapi.stream",
+      "mines.cloudapi.stream",
+      "topup.cloudapi.stream",
+      "wheel.cloudapi.stream",
+      "top.rodeo",
+      "herculessportslegend.cloudapi.stream",
+      "tg.cloudapi.stream",
+      "goldminer.cloudapi.stream",
+      "api.cloudapi.stream",
+      "www.dummysoftware.com",
+      "cdn.cloudapi.stream",
+      "multiaccount.cloudapi.stream",
+      "gamewss.cloudapi.stream",
+      "chat.cloudapi.stream",
+      "crm.cloudapi.stream",
+      "metal.cloudapi.stream",
+      "coin-miner.cloudapi.stream"
      ]
     }
    }


### PR DESCRIPTION
Adds domains found to be C2 infra for add-ons exfiltrating data https://socket.dev/blog/108-chrome-ext-linked-to-data-exfil-session-theft-shared-c2 